### PR TITLE
use go install instead of go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ go build -ldflags "-s -w" -o obom main.go
 ## Install
 
 ```bash
-go get github.com/sajayantony/obom
+go install github.com/sajayantony/obom@latest
 ```
 
 ## Usage


### PR DESCRIPTION
When running on go 1.20.5, I tried the current install instructions and got:
```
➜  ~ go get github.com/sajayantony/obom
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```
Updated command worked for me
